### PR TITLE
Only allow minor & patch dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,14 @@ updates:
     groups:
       dev-deps:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
       prod-deps:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
     assignees:
       - "sleberknight"
       - "chrisrohr"


### PR DESCRIPTION
Configure dependabot to only include minor and patch versions as part of grouped PRs.